### PR TITLE
Allow selection of text in a descendant element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /bower_components
+*~

--- a/README.md
+++ b/README.md
@@ -15,13 +15,24 @@ Angular.js directive for selecting text content on click.
 ### Example Usage
 
 ```html
-<code select-text>Clicking this code block selects the entire text within the code block</code>
+<code select-text>
+  Clicking this code block selects the entire text within the code block
+</code>
+
+<div select-text>
+  Clicking this div selects only the text in
+  <span select-text-target>this span element</span>
+</div>
 ```
 
 ### Running Tests
 
 ```
-npm install -g grunt-cli bower
-bower install
+npm install grunt-cli bower
+./node_modules/bower/bin/bower install
+npm install
 npm test
 ```
+
+On Debian, first install some dependencies by running
+`apt-get install node npm node-legacy`.

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,9 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": ">=1",
+    "angular": ">=1"
+  },
+  "devDependencies": {
     "angular-mocks": ">=1"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,6 @@ module.exports = function(config) {
     ],
 
     autoWatch: true,
-    browsers: ['Chrome']
+    browsers: ['Chrome', 'Firefox']
   });
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Angular.js directive for selecting text content.",
   "main": "angular-select-text.js",
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start --browsers Firefox --single-run"
+    "test": "./node_modules/karma/bin/karma start --single-run"
   },
   "repository": {
     "type": "git",

--- a/src/angular-select-text.js
+++ b/src/angular-select-text.js
@@ -3,27 +3,48 @@
  * angular-select-text directive
  */
 angular.module('angular-select-text', []).
-  directive('selectText', ['$window', function ($window) {
-    var selectElement;
-
+  service('selectElement', ['$window', function($window) {
     if ($window.document.selection) {
-      selectElement = function(element) {
+      return function(element) {
         var range = $window.document.body.createTextRange();
         range.moveToElementText(element[0]);
         range.select();
       };
     } else if ($window.getSelection) {
-      selectElement = function(element) {
+      return function(element) {
         var range = $window.document.createRange();
         range.selectNode(element[0]);
+        $window.getSelection().removeAllRanges();
         $window.getSelection().addRange(range);
       };
     }
+  }]).
 
+  directive('selectText', ['selectElement', function (selectElement) {
     return {
       restrict: 'A',
+      controller: ['$scope', function($scope) {
+        this.register = function(callback) {
+          $scope.callback = callback;
+        };
+      }],
       link: function(scope, element, attrs){
         element.bind('click', function(){
+          if (scope.callback)
+            scope.callback();
+          else
+            selectElement(element);
+        });
+      }
+    };
+  }]).
+
+  directive('selectTextTarget', ['selectElement', function(selectElement) {
+    return {
+      restrict: 'A',
+      require: '^selectText',
+      link: function(scope, element, attrs, selectText) {
+        selectText.register(function() {
           selectElement(element);
         });
       }

--- a/src/angular-select-text.js
+++ b/src/angular-select-text.js
@@ -23,15 +23,12 @@ angular.module('angular-select-text', []).
   directive('selectText', ['selectElement', function (selectElement) {
     return {
       restrict: 'A',
-      controller: ['$scope', function($scope) {
-        this.register = function(callback) {
-          $scope.callback = callback;
-        };
-      }],
-      link: function(scope, element, attrs){
+      require: 'selectText',
+      controller: [function() {}],
+      link: function(scope, element, attrs, selectText){
         element.bind('click', function(){
-          if (scope.callback)
-            scope.callback();
+          if (selectText.callback)
+            selectText.callback();
           else
             selectElement(element);
         });
@@ -44,8 +41,11 @@ angular.module('angular-select-text', []).
       restrict: 'A',
       require: '^selectText',
       link: function(scope, element, attrs, selectText) {
-        selectText.register(function() {
+        selectText.callback = function() {
           selectElement(element);
+        };
+        scope.$on('$destroy', function() {
+          selectText.callback = null;
         });
       }
     };

--- a/test/selectTextSpec.js
+++ b/test/selectTextSpec.js
@@ -11,28 +11,47 @@ describe('angular-select-text', function() {
         'hello world' +
       '</div>');
 
+    elmWithTarget = angular.element(
+      '<div id="selection2" select-text>' +
+        'hello ' +
+        '<span select-text-target>world</span>' +
+      '</div>');
+
     getSelection = function() {
       var text = "";
       if ($window.getSelection) {
         text = $window.getSelection().toString();
-      } else if ($window.document.selection && $window.document.selection.type != "Control") {
+      } else if ($window.document.selection &&
+                 $window.document.selection.type != "Control") {
         text = $window.document.selection.createRange().text;
       }
       return text;
     };
 
     angular.element($window.document.body).append(elm);
+    angular.element($window.document.body).append(elmWithTarget);
 
-    scope = $rootScope;
+    scope = $rootScope.$new();
     $compile(elm)(scope);
-    scope.$digest();
+
+    scope = $rootScope.$new();
+    $compile(elmWithTarget)(scope);
+
+    $rootScope.$digest();
   }));
 
-  it('should be clickable', function() {
+  it('should select all on click', function() {
     expect(elm.length).toBe(1);
     expect(elm.text()).toBe('hello world');
     elm[0].click();
-    expect(getSelection()).toBe('hello world');
+    expect(getSelection().trim()).toBe('hello world');
+  });
+
+  it('should select a descendant on click', function() {
+    expect(elmWithTarget.length).toBe(1);
+    expect(elmWithTarget.text()).toBe('hello world');
+    elmWithTarget[0].click();
+    expect(getSelection().trim()).toBe('world');
   });
 
 });


### PR DESCRIPTION
This adds the ability to select a descendant, instead of selecting all text in the clicked element.

``` html
<div select-text>
  Clicking this div selects only the text in
  <span select-text-target>this span element</span>
</div>
```

Also updated some docs and added a unit test for the new behaviour.
